### PR TITLE
feat: add back Python 3.7

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -40,6 +40,4 @@ jobs:
           python-version: ${{ matrix.python.runs-on }}
       - run: python -m pip install -U pip wheel
       - run: python -m pip install -r requirements.txt
-      - run: |
-          python -V
-          python -X utf8 bench-json.py
+      - run: python -X utf8 bench-json.py

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,11 +14,13 @@ jobs:
         os:
           - emoji: 🐧
             runs-on: [ubuntu-latest]
-          # - emoji: 🍎
-          #   runs-on: [macos-latest]
-          # - emoji: 🪟
-          #   runs-on: [windows-latest]
+          - emoji: 🍎
+            runs-on: [macos-latest]
+          - emoji: 🪟
+            runs-on: [windows-latest]
         python:
+          - name: CPython 3.7
+            runs-on: "3.7"
           - name: CPython 3.8
             runs-on: "3.8"
           - name: CPython 3.9
@@ -40,4 +42,4 @@ jobs:
       - run: python -m pip install -r requirements.txt
       - run: |
           python -V
-          python bench-json.py
+          python -X utf8 bench-json.py

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Current cross-versions winner: `python-rapidjson` :tada:
 
 ### Python 3.12
 
-```bash
+```diff
 Python 3.12.0a7
     json        loads: 2.676 x1.0 | dumps: 4.561 x1.0 ✅
     fast_json   loads: 2.151 x0.8 | dumps: 5.842 x1.3 ❌
@@ -25,7 +25,7 @@ Potential candidates = 'rapidjson, ujson'
 
 ### Python 3.11
 
-```bash
+```diff
 Python 3.11.3
     json        loads: 2.880 x1.0 | dumps: 4.389 x1.0 ✅
     fast_json   loads: 1.990 x0.7 | dumps: 5.697 x1.3 ❌
@@ -38,7 +38,7 @@ Potential candidates = 'rapidjson, ujson'
 
 ### Python 3.10
 
-```bash
+```diff
 Python 3.10.11
     json        loads: 3.652 x1.0 | dumps: 5.241 x1.0 ✅
     fast_json   loads: 2.415 x0.7 | dumps: 6.978 x1.3 ❌
@@ -51,7 +51,7 @@ Potential candidates = 'rapidjson, ujson'
 
 ### Python 3.9
 
-```bash
+```diff
 Python 3.9.16
     json        loads: 3.271 x1.0 | dumps: 4.765 x1.0 ✅
     fast_json   loads: 2.150 x0.7 | dumps: 6.435 x1.4 ❌
@@ -64,8 +64,21 @@ Potential candidates = 'rapidjson, ujson'
 
 ### Python 3.8
 
-```bash
+```diff
 Python 3.8.16
+    json        loads: 3.359 x1.0 | dumps: 4.779 x1.0 ✅
+    fast_json   loads: 2.077 x0.6 | dumps: 6.900 x1.4 ❌
+    rapidjson   loads: 2.253 x0.7 | dumps: 1.921 x0.4 ✅
+    simplejson  loads: 3.973 x1.2 | dumps: 8.552 x1.8 ❌
+    ujson       loads: 2.149 x0.6 | dumps: 2.606 x0.5 ✅
+
+Potential candidates = 'rapidjson, ujson'
+```
+
+### Python 3.7
+
+```diff
+Python 3.7.xx
     json        loads: 3.359 x1.0 | dumps: 4.779 x1.0 ✅
     fast_json   loads: 2.077 x0.6 | dumps: 6.900 x1.4 ❌
     rapidjson   loads: 2.253 x0.7 | dumps: 1.921 x0.4 ✅

--- a/README.md
+++ b/README.md
@@ -8,84 +8,73 @@ See the [requirements.txt](requirements.txt) file for exact modules being tested
 
 ## Results
 
-Current cross-versions winner: `python-rapidjson` :tada:
+- GNU/Linux + macOS: current cross-versions winner is `python-rapidjson` :tada:
+- Windows: current cross-versions winner is `ujson` :tada:
 
 ### Python 3.12
 
 ```diff
-Python 3.12.0a7
-    json        loads: 2.676 x1.0 | dumps: 4.561 x1.0 ✅
-    fast_json   loads: 2.151 x0.8 | dumps: 5.842 x1.3 ❌
-    rapidjson   loads: 2.128 x0.8 | dumps: 2.121 x0.5 ✅
-    simplejson  loads: 24.037 x9.0 | dumps: 28.560 x6.3 ❌
-    ujson       loads: 2.184 x0.8 | dumps: 2.597 x0.6 ✅
-
-Potential candidates = 'rapidjson, ujson'
+@@ Python 3.12.0 @@
++ rapidjson… loads:  2.005  x0.7 | dumps:  2.142  x0.5
++ ujson…………… loads:  2.118  x0.8 | dumps:  2.508  x0.6
+! json……………… loads:  2.694  x1.0 | dumps:  4.261  x1.0
+- fast_json… loads:  2.092  x0.8 | dumps:  5.578  x1.3
+- simplejson loads: 25.065  x9.3 | dumps: 27.842  x6.5
 ```
 
 ### Python 3.11
 
 ```diff
-Python 3.11.3
-    json        loads: 2.880 x1.0 | dumps: 4.389 x1.0 ✅
-    fast_json   loads: 1.990 x0.7 | dumps: 5.697 x1.3 ❌
-    rapidjson   loads: 2.065 x0.7 | dumps: 1.772 x0.4 ✅
-    simplejson  loads: 3.221 x1.1 | dumps: 9.158 x2.1 ❌
-    ujson       loads: 1.985 x0.7 | dumps: 2.282 x0.5 ✅
-
-Potential candidates = 'rapidjson, ujson'
+@@ Python 3.11.3 @@
++ rapidjson… loads:  1.995  x0.7 | dumps:  1.764  x0.4
++ ujson…………… loads:  2.203  x0.7 | dumps:  2.185  x0.5
+! json……………… loads:  3.014  x1.0 | dumps:  4.846  x1.0
+- fast_json… loads:  2.197  x0.7 | dumps:  5.838  x1.2
+- simplejson loads:  3.172  x1.1 | dumps:  8.808  x1.8
 ```
 
 ### Python 3.10
 
 ```diff
-Python 3.10.11
-    json        loads: 3.652 x1.0 | dumps: 5.241 x1.0 ✅
-    fast_json   loads: 2.415 x0.7 | dumps: 6.978 x1.3 ❌
-    rapidjson   loads: 2.217 x0.6 | dumps: 1.908 x0.4 ✅
-    simplejson  loads: 4.008 x1.1 | dumps: 10.494 x2.0 ❌
-    ujson       loads: 2.351 x0.6 | dumps: 2.343 x0.4 ✅
-
-Potential candidates = 'rapidjson, ujson'
+@@ Python 3.10.11 @@
++ rapidjson… loads:  2.048  x0.6 | dumps:  1.821  x0.4
++ ujson…………… loads:  2.260  x0.7 | dumps:  2.265  x0.5
+! json……………… loads:  3.277  x1.0 | dumps:  4.900  x1.0
+- fast_json… loads:  2.201  x0.7 | dumps:  6.432  x1.3
+- simplejson loads:  3.626  x1.1 | dumps:  9.292  x1.9
 ```
 
 ### Python 3.9
 
 ```diff
-Python 3.9.16
-    json        loads: 3.271 x1.0 | dumps: 4.765 x1.0 ✅
-    fast_json   loads: 2.150 x0.7 | dumps: 6.435 x1.4 ❌
-    rapidjson   loads: 2.116 x0.6 | dumps: 1.868 x0.4 ✅
-    simplejson  loads: 3.752 x1.1 | dumps: 8.030 x1.7 ❌
-    ujson       loads: 2.176 x0.7 | dumps: 2.180 x0.5 ✅
-
-Potential candidates = 'rapidjson, ujson'
+@@ Python 3.9.16 @@
++ rapidjson… loads:  2.520  x0.6 | dumps:  2.266  x0.4
++ ujson…………… loads:  2.714  x0.7 | dumps:  2.810  x0.5
+! json……………… loads:  4.149  x1.0 | dumps:  6.036  x1.0
+- fast_json… loads:  2.670  x0.6 | dumps:  8.192  x1.4
+- simplejson loads:  4.694  x1.1 | dumps: 10.459  x1.7
 ```
 
 ### Python 3.8
 
 ```diff
-Python 3.8.16
-    json        loads: 3.359 x1.0 | dumps: 4.779 x1.0 ✅
-    fast_json   loads: 2.077 x0.6 | dumps: 6.900 x1.4 ❌
-    rapidjson   loads: 2.253 x0.7 | dumps: 1.921 x0.4 ✅
-    simplejson  loads: 3.973 x1.2 | dumps: 8.552 x1.8 ❌
-    ujson       loads: 2.149 x0.6 | dumps: 2.606 x0.5 ✅
-
-Potential candidates = 'rapidjson, ujson'
+@@ Python 3.8.16 @@
++ rapidjson… loads:  2.565  x0.6 | dumps:  2.150  x0.4
++ ujson…………… loads:  2.610  x0.6 | dumps:  3.006  x0.6
+! json……………… loads:  4.042  x1.0 | dumps:  5.406  x1.0
+- fast_json… loads:  2.441  x0.6 | dumps:  7.763  x1.4
+- simplejson loads:  4.436  x1.1 | dumps: 10.150  x1.9
 ```
 
 ### Python 3.7
 
 ```diff
-Python 3.7.xx
-    json        loads: 3.359 x1.0 | dumps: 4.779 x1.0 ✅
-    fast_json   loads: 2.077 x0.6 | dumps: 6.900 x1.4 ❌
-    rapidjson   loads: 2.253 x0.7 | dumps: 1.921 x0.4 ✅
-    simplejson  loads: 3.973 x1.2 | dumps: 8.552 x1.8 ❌
-    ujson       loads: 2.149 x0.6 | dumps: 2.606 x0.5 ✅
-
-Potential candidates = 'rapidjson, ujson'
+@@ Python 3.7.16 @@
++ rapidjson… loads:  2.494  x0.6 | dumps:  2.155  x0.4
++ ujson…………… loads:  2.813  x0.7 | dumps:  2.821  x0.5
+! json……………… loads:  4.120  x1.0 | dumps:  5.662  x1.0
+- fast_json… loads:  2.632  x0.6 | dumps:  7.649  x1.4
+- simplejson loads:  4.836  x1.2 | dumps: 10.162  x1.8
 ```
 
 ## Not An Option


### PR DESCRIPTION
Also:
- sort results
- adjust the padding
- run the CI on MacOS, and Windows too

New output with colors on the README, preview:

```diff
@@ Python 3.11.0 @@
+ rapidjson… loads:  1.405  x0.7 | dumps:  1.220  x0.4
+ ujson…………… loads:  1.536  x0.8 | dumps:  1.491  x0.5
! json……………… loads:  1.956  x1.0 | dumps:  3.189  x1.0
- fast_json… loads:  -.---  x-.- | dumps:  -.---  x-.-
- simplejson loads:  -.---  x-.- | dumps:  -.---  x-.-
```